### PR TITLE
Remove DependencyInfoBlock for F-Droid

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,6 +65,12 @@ android {
     buildFeatures {
         compose = true
     }
+    dependenciesInfo {
+        // Disables dependency metadata when building APKs.
+        includeInApk = false
+        // Disables dependency metadata when building Android App Bundles.
+        includeInBundle = false
+    }
 }
 
 dependencies {


### PR DESCRIPTION
We find that there is a DependencyInfoBlock in your APK.

It's a [Signing block](https://source.android.com/docs/security/features/apksigning/v2#apk-signing-block) added by AGP and encrypted with the Google public key so it can't be read by anyone else except Google. You can read more about it [here](https://gitlab.com/fdroid/admin/-/issues/367), [here](https://gitlab.com/fdroid/fdroidserver/-/issues/1056) and [here](https://android.izzysoft.de/articles/named/iod-scan-apkchecks?lang=en#blobs).

While this was added a while ago, we were only enforcing it for new apps, and recently we started scanning updates too.

Could you please disable it with the following code?

```
android {
    dependenciesInfo {
        // Disables dependency metadata when building APKs.
        includeInApk = false
        // Disables dependency metadata when building Android App Bundles.
        includeInBundle = false
    }
}
```

Thanks!